### PR TITLE
trigger rebuild due to malformed libffi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - no-cocoa-notification.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Turns out pkgconfig can propagate these lib64 errors