### PR TITLE
gdesktopappinfo 

### DIFF
--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -10,8 +10,8 @@ pin_run_as_build:
   libiconv:
     max_pin: x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -16,8 +16,8 @@ pin_run_as_build:
   libiconv:
     max_pin: x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (`@conda-forge-admin, please rerender`)
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@
 _PY=$PYTHON
 export PYTHON="python"
 
+autoreconf -i -f
 ./configure --prefix="${PREFIX}" \
             --with-python=${PYTHON} \
             --with-libiconv=gnu \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ build:
 requirements:
   build:
     - make
+    - autoconf
+    - automake
     - pkg-config
     - {{ compiler('c') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     #
     - hardcoded-paths.patch
     # Not sure why test_stdio_wrappers do not pass, skipping it for now.
-    - no_fileutils_test.patch
+    #- no_fileutils_test.patch
 
 build:
   number: 2
@@ -27,6 +27,7 @@ build:
 
 requirements:
   build:
+    - make
     - pkg-config
     - {{ compiler('c') }}
   host:
@@ -46,6 +47,7 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libglib-2.0{{ SHLIB_EXT }}  # [not win]
+    - test -f ${PREFIX}/include/gio-unix-2.0/gio/gdesktopappinfo.h  # [not win]
     - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - make
     - autoconf
     - automake
+    - libtool
     - pkg-config
     - {{ compiler('c') }}
   host:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (`@conda-forge-admin, please rerender`)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

the gdesktopappinfo.h file is no longer present on mac builds, which is causing issues downstream, such as in glibmm.
