### PR TITLE
Export pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,11 @@ source:
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
 build:
-  number: 1000
+  number: 1001
   skip: True  # [not py36]
   detect_binary_files_with_prefix: True
+  run_exports:
+    - {{ pin_subpackage('glib') }}
 
 requirements:
   build:


### PR DESCRIPTION
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

fixes #38

Binaries linked with `glib 2.56.1` and run with `glib 2.55.1` lead to

```
dyld: Library not loaded: @rpath/libglib-2.0.0.dylib
  Referenced from: PATH/XXXX
Reason: Incompatible library version: XXXX requires version 5601.0.0 or later, but libglib-2.0.0.dylib provides version 5501.0.0
```

Question: I took `pin_subpackage` from other recipes. Why is it not `pin_compatible`? Anyone know where to find documentation on these?
