### PR TITLE
Fix linux binaries

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,6 +15,10 @@ cd forgebuild
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig
 
+@REM Avoid a Meson issue - https://github.com/mesonbuild/meson/issues/4827
+set "PYTHONLEGACYWINDOWSSTDIO=1"
+set "PYTHONIOENCODING=UTF-8"
+
 %PYTHON% %PREFIX%\Scripts\meson --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Diconv=gnu -Dselinux=false -Dxattr=false -Dlibmount=false ..
 if errorlevel 1 exit 1
 

--- a/recipe/meson-rpaths.patch
+++ b/recipe/meson-rpaths.patch
@@ -1,17 +1,17 @@
 As per https://github.com/conda-forge/glib-feedstock/issues/40, the new Meson
-build system can cause an obscure problem on Linux. When installing
-executables (including shared libraries), Meson edits their RPATHs. When no
-"install_rpath" setting has been configured, Meson removes the RPATH entry. The
-way it does so is legal, but ends up altering the file structure in a way that
-a few naive programs can't handle. One of those programs is ldconfig, and its
-confusion can result in it trying to create files with junk names, which then
-confuse downstream tools.
+build system can cause problems on Linux. When installing executables
+(including shared libraries), Meson edits their RPATHs. When no
+"install_rpath" setting has been configured, Meson removes the RPATH entry.
+First, this can break our executables. Second, historically, the way that
+Meson does so was legal, but ends up altering the file structure in a way
+that a few naive programs can't handle. One of those programs is ldconfig, and
+its confusion can result in it trying to create files with junk names, which
+then confuse downstream tools.
 
-By setting the install rpath to something nonempty, the deletion codepath is
-avoided and everything is copacetic.
+So we the install rpath to something nonempty.
 
 diff --git a/glib/meson.build b/glib/meson.build
-index 6fc56da..623236d 100644
+index 6fc56da..4cfc08d 100644
 --- a/glib/meson.build
 +++ b/glib/meson.build
 @@ -257,6 +257,7 @@ libglib = library('glib-2.0',
@@ -22,11 +22,27 @@ index 6fc56da..623236d 100644
    # intl.lib is not compatible with SAFESEH
    link_args : [noseh_link_args, glib_link_flags, win32_ldflags],
    include_directories : configinc,
+@@ -315,6 +316,7 @@ if host_system == 'windows'
+ else
+   gtester = executable('gtester', 'gtester.c',
+     install : true,
++    install_rpath : glib_libdir,
+     include_directories : configinc,
+     dependencies : [libglib_dep])
+ endif
 diff --git a/gio/meson.build b/gio/meson.build
-index 7f2c08e..f001a20 100644
+index 7f2c08e..871075b 100644
 --- a/gio/meson.build
 +++ b/gio/meson.build
-@@ -798,6 +798,7 @@ libgio = library('gio-2.0',
+@@ -423,6 +423,7 @@ if host_system != 'windows'
+ 
+     executable('gio-launch-desktop', 'gio-launch-desktop.c',
+       install : true,
++      install_rpath : glib_libdir,
+       c_args : gio_c_args,
+       # intl.lib is not compatible with SAFESEH
+       link_args : noseh_link_args)
+@@ -798,6 +799,7 @@ libgio = library('gio-2.0',
    version : library_version,
    soversion : soversion,
    install : true,
@@ -34,8 +50,71 @@ index 7f2c08e..f001a20 100644
    include_directories : [configinc, gioinc],
    #  '$(gio_win32_res_ldflag)',
    dependencies : [libz_dep, libdl_dep, libmount_dep, libglib_dep,
+@@ -919,6 +921,7 @@ gio_tool_sources = [
+ 
+ executable('gio', gio_tool_sources,
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -926,12 +929,14 @@ executable('gio', gio_tool_sources,
+ 
+ executable('gresource', 'gresource-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+   dependencies : [libelf, libgio_dep, libgobject_dep, libgmodule_dep, libglib_dep])
+ 
+ gio_querymodules = executable('gio-querymodules', 'gio-querymodules.c', 'giomodule-priv.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -940,6 +945,7 @@ gio_querymodules = executable('gio-querymodules', 'gio-querymodules.c', 'giomodu
+ glib_compile_schemas = executable('glib-compile-schemas',
+   [gconstructor_as_data_h, 'gvdb/gvdb-builder.c', 'glib-compile-schemas.c'],
+   install : true,
++  install_rpath : glib_libdir,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+   dependencies : [libgio_dep, libgobject_dep, libgmodule_dep, libglib_dep])
+@@ -947,6 +953,7 @@ glib_compile_schemas = executable('glib-compile-schemas',
+ glib_compile_resources = executable('glib-compile-resources',
+   [gconstructor_as_data_h, 'gvdb/gvdb-builder.c', 'glib-compile-resources.c'],
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -954,6 +961,7 @@ glib_compile_resources = executable('glib-compile-resources',
+ 
+ executable('gsettings', 'gsettings-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -966,6 +974,7 @@ install_data(['gschema.loc', 'gschema.its'],
+ 
+ executable('gdbus', 'gdbus-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -974,6 +983,7 @@ executable('gdbus', 'gdbus-tool.c',
+ if host_system != 'windows' and not glib_have_cocoa
+   executable('gapplication', 'gapplication-tool.c',
+     install : true,
++    install_rpath : glib_libdir,
+     c_args : gio_c_args,
+     # intl.lib is not compatible with SAFESEH
+     link_args : noseh_link_args,
 diff --git a/gobject/meson.build b/gobject/meson.build
-index d8d421d..b16cf1d 100644
+index d8d421d..1a7d320 100644
 --- a/gobject/meson.build
 +++ b/gobject/meson.build
 @@ -67,6 +67,7 @@ libgobject = library('gobject-2.0',
@@ -46,6 +125,14 @@ index d8d421d..b16cf1d 100644
    include_directories : [configinc],
    dependencies : [libffi_dep, libglib_dep],
    c_args : ['-DG_LOG_DOMAIN="GLib-GObject"', '-DGOBJECT_COMPILATION'] + glib_hidden_visibility_args,
+@@ -111,6 +112,7 @@ endforeach
+ 
+ executable('gobject-query', 'gobject-query.c',
+   install : true,
++  install_rpath : glib_libdir,
+   dependencies : [libglib_dep, libgobject_dep])
+ 
+ install_data('gobject_gdb.py', install_dir : join_paths(glib_pkgdatadir, 'gdb'))
 diff --git a/gmodule/meson.build b/gmodule/meson.build
 index 8bb6189..be254f3 100644
 --- a/gmodule/meson.build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    # The meson version pin is to avoid a buggy package; see
-    # meson-feedstock issue #11.
-    - meson <0.48  # [win]
-    - meson        # [not win]
+    - meson
     - python
     - libffi
     - gettext

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ test:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
     # Check that binaries can run -- instigated by Meson Linux rpath issue
-    - gapplication help
+    - gapplication help  # [linux]
     - gdbus help
     - gio version
     - gio-querymodules .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,8 @@ source:
     - 0001-Manually-link-with-libiconv-whenever-we-use-libintl.patch  # [win]
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
-
-
 build:
-  number: 1001
+  number: 1002
   skip: True  # [not py36]
   run_exports:
     - {{ pin_subpackage('glib') }}
@@ -63,6 +61,16 @@ test:
     - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    # Check that binaries can run -- instigated by Meson Linux rpath issue
+    - gapplication help
+    - gdbus help
+    - gio version
+    - gio-querymodules .
+    - glib-compile-resources --help
+    - glib-compile-schemas --help
+    - gobject-query --help
+    - gresource help
+    - gtester --help
 
 about:
   home: https://developer.gnome.org/glib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ test:
     - glib-compile-schemas --help
     - gobject-query --help
     - gresource help
-    - gtester --help
+    - gtester --help  # [not win]
 
 about:
   home: https://developer.gnome.org/glib/


### PR DESCRIPTION
Newest Meson broke the binaries we install on Linux; fix the problem and add test infrastructure to try to prevent reoccurences.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.