### PR TITLE
2.58 again

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -2,6 +2,7 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
+
 jobs:
 - job: linux
   pool:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,20 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_python3.6.____73_pypy:
+        CONFIG: linux_64_python3.6.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.6.____cpython:
+        CONFIG: linux_64_python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.7.____cpython:
+        CONFIG: linux_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpython:
+        CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,17 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_python3.6.____73_pypy:
+        CONFIG: osx_64_python3.6.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.6.____cpython:
+        CONFIG: osx_64_python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpython:
+        CONFIG: osx_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpython:
+        CONFIG: osx_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_:
         CONFIG: osx_arm64_

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,14 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_64_:
-        CONFIG: win_64_
+      win_64_python3.6.____cpython:
+        CONFIG: win_64_python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.7.____cpython:
+        CONFIG: win_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpython:
+        CONFIG: win_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.6.____73_pypy.yaml
@@ -1,32 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.10'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
   libiconv:
     max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- 3.6.* *_73_pypy
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -1,15 +1,11 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-comp7
 libffi:
 - '3.3'
 libiconv:
@@ -27,10 +23,15 @@ pin_run_as_build:
     max_pin: x.x
   libiconv:
     max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- 3.6.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -1,23 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-comp7
 libffi:
 - '3.3'
 libiconv:
@@ -23,10 +23,15 @@ pin_run_as_build:
     max_pin: x.x
   libiconv:
     max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____73_pypy.yaml
@@ -1,23 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +33,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_73_pypy
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -1,23 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +33,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -1,23 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +33,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -1,23 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -31,7 +35,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____73_pypy.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-ppc64le
 libffi:
 - '3.3'
 libiconv:
@@ -23,10 +23,15 @@ pin_run_as_build:
     max_pin: x.x
   libiconv:
     max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- 3.6.* *_73_pypy
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
@@ -1,23 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
@@ -1,23 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -1,23 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -31,7 +31,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.6.____73_pypy.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +17,7 @@ libffi:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_73_pypy
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +17,7 @@ libffi:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +17,7 @@ libffi:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,9 +29,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 c_compiler:
 - clang
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -17,7 +17,7 @@ libffi:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -31,7 +31,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_python3.6.____cpython.yaml
+++ b/.ci_support/win_64_python3.6.____cpython.yaml
@@ -1,23 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
-c_compiler_version:
-- '11'
+- vs2017
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '11'
+- vs2017
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,11 +21,8 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
+- win-64
 zlib:
 - '1.2'

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -1,23 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
-c_compiler_version:
-- '11'
+- vs2017
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '11'
+- vs2017
 libffi:
 - '3.3'
 libiconv:
 - '1.16'
-macos_machine:
-- arm64-apple-darwin20.0.0
 pin_run_as_build:
   libffi:
     max_pin: x.x
@@ -29,11 +21,8 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
+- win-64
 zlib:
 - '1.2'

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -15,8 +15,13 @@ pin_run_as_build:
     max_pin: x.x
   libiconv:
     max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- 3.8.* *_cpython
 target_platform:
 - win-64
 zlib:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_
+name: linux_aarch64_python3.6.____73_pypy
 
 platform:
   os: linux
@@ -10,7 +10,100 @@ steps:
 - name: Install and build
   image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_
+    CONFIG: linux_aarch64_python3.6.____73_pypy
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_python3.6.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_python3.6.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_python3.7.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_python3.7.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_python3.8.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_python3.8.____cpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,19 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/README.md
+++ b/README.md
@@ -41,31 +41,115 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_python3.6.____73_pypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_64_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_64_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.6.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.6.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -76,10 +160,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64</td>
+              <td>win_64_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=win&configuration=win_64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=369&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/glib-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/0001-Manually-link-with-libiconv-whenever-we-use-libintl.patch
+++ b/recipe/0001-Manually-link-with-libiconv-whenever-we-use-libintl.patch
@@ -1,33 +1,19 @@
-commit 7bb34f6eaf691d9fc18c1a75df8f70713a9d8108
-Author: Isuru Fernando <isuruf@gmail.com>
-Date:   Sun Apr 5 23:57:06 2020 +0000
+From 373f953aa1a2009f05a6c1d6ee73fda21d9cabfc Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Mon, 3 Sep 2018 22:27:48 -0400
+Subject: [PATCH 1/2] Manually link with libiconv whenever we use libintl.
 
-    Manually link with libiconv whenever we use libintl.
-    
-    Sadly our Windows libintl DLL doesn't convey that it should pull in libiconv
-    as a dependency (nor does it use pkg-config). Until I figure that out, let's
-    just manually link with libintl when needed.
-    
-    There is also some hacking of gconvert.c and the toplevel meson.build file
-    needed to adjust the build system -- it assumes that on Windows you're always
-    going to use an internal iconv.
-    
-    Original Author: Peter Williams <peter@newton.cx>
+Sadly our Windows libintl DLL doesn't convey that it should pull in libiconv
+as a dependency (nor does it use pkg-config). Until I figure that out, let's
+just manually link with libintl when needed.
 
-diff --git a/gio/win32/meson.build b/gio/win32/meson.build
-index 8d58998..4388c34 100644
---- a/gio/win32/meson.build
-+++ b/gio/win32/meson.build
-@@ -10,6 +10,6 @@ giowin32_sources = [
- giowin32_lib = static_library('giowin32',
-   sources : [giowin32_sources],
-   include_directories : [configinc, glibinc, gioinc, gmoduleinc],
--  dependencies : [libintl, gioenumtypes_dep],
-+  dependencies : [libintl, gioenumtypes_dep] + libiconv,
-   pic : true,
-   c_args : gio_c_args)
+There is also some hacking of gconvert.c and the toplevel meson.build file
+needed to adjust the build system -- it assumes that on Windows you're always
+going to use an internal iconv.
+---
+
 diff --git a/glib/gconvert.c b/glib/gconvert.c
-index c5857df..98d4b36 100644
+index 5028647..f685a06 100644
 --- a/glib/gconvert.c
 +++ b/glib/gconvert.c
 @@ -21,18 +21,12 @@
@@ -50,15 +36,45 @@ index c5857df..98d4b36 100644
  #define STRICT
  #include <windows.h>
 diff --git a/meson.build b/meson.build
-index e1b4b79..9860697 100644
+index 0cc6e94..f256075 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1815,7 +1815,7 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
- # available in the actual runtime environment. On Windows, we always use
- # the built-in implementation
- iconv_opt = get_option('iconv')
+@@ -1673,7 +1673,7 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
+ # GNU implementation that ships with MinGW.
+ 
+ # On Windows, just always use the built-in implementation
 -if host_system == 'windows'
 +if host_system == 'IGNOREME windows'
    libiconv = []
-   # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
-   # any external library for it
+   glib_conf.set('USE_LIBICONV_NATIVE', true)
+ else
+diff --git a/glib/meson.build b/glib/meson.build
+index 6fc56da..66db78c 100644
+--- a/glib/meson.build
++++ b/glib/meson.build
+@@ -268,11 +268,11 @@ libglib_dep = declare_dependency(
+   link_with : libglib,
+   # thread_dep doesn't get pulled in from libglib atm,
+   # see https://github.com/mesonbuild/meson/issues/1426
+-  dependencies : [thread_dep, libintl],
++  dependencies : [thread_dep, libintl] + libiconv,
+   # We sadly need to export configinc here because everyone includes <glib/*.h>
+   include_directories : [configinc, glibinc])
+ 
+-pkg.generate(libraries : [libglib, libintl],
++pkg.generate(libraries : [libglib, libintl] + libiconv,
+   libraries_private : [osx_ldflags, win32_ldflags],
+   subdirs : ['glib-2.0'],
+   extra_cflags : ['-I${libdir}/glib-2.0/include'] + win32_cflags,
+diff --git a/gio/win32/meson.build b/gio/win32/meson.build
+index c1841cb..dc84cca 100644
+--- a/gio/win32/meson.build
++++ b/gio/win32/meson.build
+@@ -10,6 +10,6 @@ giowin32_sources = [
+ giowin32_lib = static_library('giowin32',
+   sources : [giowin32_sources, gioenumtypes_h],
+   include_directories : [configinc, glibinc, gioinc, gmoduleinc],
+-  dependencies : [libintl],
++  dependencies : [libintl] + libiconv,
+   pic : true,
+   c_args : [ '-DG_DISABLE_DEPRECATED' ] + gio_c_args)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - 10.10                  # [osx and x86_64]

--- a/recipe/hardcoded-paths.patch
+++ b/recipe/hardcoded-paths.patch
@@ -1,49 +1,54 @@
+commit 790d6a0335939f6ea5fedc30286d8604552e8b70
+Author: Peter Williams <peter@newton.cx>
+Date:   Mon Sep 3 22:23:15 2018 -0400
+
+    All-plat patch: hardcoded_paths
+
 diff --git a/gio/gdbusprivate.c b/gio/gdbusprivate.c
-index 1e8e1d6..5ad928e 100644
+index 288c31f..4bf4f8d 100644
 --- a/gio/gdbusprivate.c
 +++ b/gio/gdbusprivate.c
-@@ -2107,7 +2107,7 @@ _g_dbus_get_machine_id (GError **error)
+@@ -2098,7 +2098,7 @@ _g_dbus_get_machine_id (GError **error)
    /* TODO: use PACKAGE_LOCALSTATEDIR ? */
    ret = NULL;
    first_error = NULL;
 -  if (!g_file_get_contents ("/var/lib/dbus/machine-id",
-+  if (!g_file_get_contents (CONDA_PREFIX "/var/lib/dbus/machine-id",
++  if (!g_file_get_contents ("@@CONDA_PREFIX@@/var/lib/dbus/machine-id",
                              &ret,
                              NULL,
                              &first_error) &&
-@@ -2117,7 +2117,7 @@ _g_dbus_get_machine_id (GError **error)
+@@ -2108,7 +2108,7 @@ _g_dbus_get_machine_id (GError **error)
                              NULL))
      {
        g_propagate_prefixed_error (error, first_error,
 -                                  _("Unable to load /var/lib/dbus/machine-id or /etc/machine-id: "));
-+                                  _("Unable to load " CONDA_PREFIX "/var/lib/dbus/machine-id or /etc/machine-id: "));
++                                  _("Unable to load @@CONDA_PREFIX@@ or /etc/machine-id: "));
      }
    else
      {
 diff --git a/gio/xdgmime/xdgmime.c b/gio/xdgmime/xdgmime.c
-index 2446d38..1042df2 100644
+index 95adf7e..25a9d1a 100644
 --- a/gio/xdgmime/xdgmime.c
 +++ b/gio/xdgmime/xdgmime.c
-@@ -235,7 +235,7 @@ xdg_init_dirs (void)
-   xdg_data_dirs = getenv ("XDG_DATA_DIRS");
+@@ -253,7 +253,7 @@ xdg_run_command_on_dirs (XdgDirectoryFunc  func,
  
+   xdg_data_dirs = getenv ("XDG_DATA_DIRS");
    if (xdg_data_dirs == NULL)
 -    xdg_data_dirs = "/usr/local/share/:/usr/share/";
-+    xdg_data_dirs = CONDA_PREFIX "/share/:/usr/share/";
++    xdg_data_dirs = "@@CONDA_PREFIX@@/share/:/usr/share/";
  
-   /* Work out how many dirs we’re dealing with. */
-   if (xdg_data_home != NULL || home != NULL)
+   ptr = xdg_data_dirs;
+ 
 diff --git a/glib/gutils.c b/glib/gutils.c
-index 2e2d457..c97259b 100644
+index 5813b22..9ab272c 100644
 --- a/glib/gutils.c
 +++ b/glib/gutils.c
-@@ -2080,7 +2080,7 @@ g_build_system_data_dirs (void)
-    */
- #ifndef G_OS_WIN32
-   if (!data_dirs || !data_dirs[0])
--    data_dirs = "/usr/local/share/:/usr/share/";
-+    data_dirs = CONDA_PREFIX "/share/:/usr/share/";
+@@ -2040,7 +2040,7 @@ g_get_system_data_dirs (void)
  
-   data_dir_vector = g_strsplit (data_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
+ #ifndef G_OS_WIN32
+       if (!data_dirs || !data_dirs[0])
+-          data_dirs = "/usr/local/share/:/usr/share/";
++          data_dirs = "@@CONDA_PREFIX@@/share/:/usr/share/";
+ 
+       data_dir_vector = g_strsplit (data_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
  #else
-

--- a/recipe/meson-rpaths.patch
+++ b/recipe/meson-rpaths.patch
@@ -1,0 +1,159 @@
+As per https://github.com/conda-forge/glib-feedstock/issues/40, the new Meson
+build system can cause problems on Linux. When installing executables
+(including shared libraries), Meson edits their RPATHs. When no
+"install_rpath" setting has been configured, Meson removes the RPATH entry.
+First, this can break our executables. Second, historically, the way that
+Meson does so was legal, but ends up altering the file structure in a way
+that a few naive programs can't handle. One of those programs is ldconfig, and
+its confusion can result in it trying to create files with junk names, which
+then confuse downstream tools.
+
+So we the install rpath to something nonempty.
+
+diff --git a/glib/meson.build b/glib/meson.build
+index 6fc56da..4cfc08d 100644
+--- a/glib/meson.build
++++ b/glib/meson.build
+@@ -257,6 +257,7 @@ libglib = library('glib-2.0',
+   version : library_version,
+   soversion : soversion,
+   install : true,
++  install_rpath : glib_libdir,
+   # intl.lib is not compatible with SAFESEH
+   link_args : [noseh_link_args, glib_link_flags, win32_ldflags],
+   include_directories : configinc,
+@@ -315,6 +316,7 @@ if host_system == 'windows'
+ else
+   gtester = executable('gtester', 'gtester.c',
+     install : true,
++    install_rpath : glib_libdir,
+     include_directories : configinc,
+     dependencies : [libglib_dep])
+ endif
+diff --git a/gio/meson.build b/gio/meson.build
+index 7f2c08e..871075b 100644
+--- a/gio/meson.build
++++ b/gio/meson.build
+@@ -423,6 +423,7 @@ if host_system != 'windows'
+ 
+     executable('gio-launch-desktop', 'gio-launch-desktop.c',
+       install : true,
++      install_rpath : glib_libdir,
+       c_args : gio_c_args,
+       # intl.lib is not compatible with SAFESEH
+       link_args : noseh_link_args)
+@@ -798,6 +799,7 @@ libgio = library('gio-2.0',
+   version : library_version,
+   soversion : soversion,
+   install : true,
++  install_rpath : glib_libdir,
+   include_directories : [configinc, gioinc],
+   #  '$(gio_win32_res_ldflag)',
+   dependencies : [libz_dep, libdl_dep, libmount_dep, libglib_dep,
+@@ -919,6 +921,7 @@ gio_tool_sources = [
+ 
+ executable('gio', gio_tool_sources,
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -926,12 +929,14 @@ executable('gio', gio_tool_sources,
+ 
+ executable('gresource', 'gresource-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+   dependencies : [libelf, libgio_dep, libgobject_dep, libgmodule_dep, libglib_dep])
+ 
+ gio_querymodules = executable('gio-querymodules', 'gio-querymodules.c', 'giomodule-priv.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -940,6 +945,7 @@ gio_querymodules = executable('gio-querymodules', 'gio-querymodules.c', 'giomodu
+ glib_compile_schemas = executable('glib-compile-schemas',
+   [gconstructor_as_data_h, 'gvdb/gvdb-builder.c', 'glib-compile-schemas.c'],
+   install : true,
++  install_rpath : glib_libdir,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+   dependencies : [libgio_dep, libgobject_dep, libgmodule_dep, libglib_dep])
+@@ -947,6 +953,7 @@ glib_compile_schemas = executable('glib-compile-schemas',
+ glib_compile_resources = executable('glib-compile-resources',
+   [gconstructor_as_data_h, 'gvdb/gvdb-builder.c', 'glib-compile-resources.c'],
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -954,6 +961,7 @@ glib_compile_resources = executable('glib-compile-resources',
+ 
+ executable('gsettings', 'gsettings-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -966,6 +974,7 @@ install_data(['gschema.loc', 'gschema.its'],
+ 
+ executable('gdbus', 'gdbus-tool.c',
+   install : true,
++  install_rpath : glib_libdir,
+   c_args : gio_c_args,
+   # intl.lib is not compatible with SAFESEH
+   link_args : noseh_link_args,
+@@ -974,6 +983,7 @@ executable('gdbus', 'gdbus-tool.c',
+ if host_system != 'windows' and not glib_have_cocoa
+   executable('gapplication', 'gapplication-tool.c',
+     install : true,
++    install_rpath : glib_libdir,
+     c_args : gio_c_args,
+     # intl.lib is not compatible with SAFESEH
+     link_args : noseh_link_args,
+diff --git a/gobject/meson.build b/gobject/meson.build
+index d8d421d..1a7d320 100644
+--- a/gobject/meson.build
++++ b/gobject/meson.build
+@@ -67,6 +67,7 @@ libgobject = library('gobject-2.0',
+   version : library_version,
+   soversion : soversion,
+   install : true,
++  install_rpath : glib_libdir,
+   include_directories : [configinc],
+   dependencies : [libffi_dep, libglib_dep],
+   c_args : ['-DG_LOG_DOMAIN="GLib-GObject"', '-DGOBJECT_COMPILATION'] + glib_hidden_visibility_args,
+@@ -111,6 +112,7 @@ endforeach
+ 
+ executable('gobject-query', 'gobject-query.c',
+   install : true,
++  install_rpath : glib_libdir,
+   dependencies : [libglib_dep, libgobject_dep])
+ 
+ install_data('gobject_gdb.py', install_dir : join_paths(glib_pkgdatadir, 'gdb'))
+diff --git a/gmodule/meson.build b/gmodule/meson.build
+index 8bb6189..be254f3 100644
+--- a/gmodule/meson.build
++++ b/gmodule/meson.build
+@@ -100,6 +100,7 @@ libgmodule = library('gmodule-2.0',
+   version : library_version,
+   soversion : soversion,
+   install : true,
++  install_rpath : glib_libdir,
+   include_directories : [configinc, gmoduleinc],
+   dependencies : [libdl_dep, libglib_dep],
+   c_args : ['-DG_LOG_DOMAIN="GModule"', '-DG_DISABLE_DEPRECATED'] + glib_hidden_visibility_args,
+diff --git a/gthread/meson.build b/gthread/meson.build
+index 515479b..0761b04 100644
+--- a/gthread/meson.build
++++ b/gthread/meson.build
+@@ -17,6 +17,7 @@ libgthread = library('gthread-2.0',
+   version : library_version,
+   soversion : soversion,
+   install : true,
++  install_rpath : glib_libdir,
+   dependencies : [libglib_dep],
+   c_args : ['-DG_LOG_DOMAIN="GThread"' ] + glib_hidden_visibility_args,
+   link_args : glib_link_flags,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
-{% set version = "2.66.3" %}
+# Previous built 2.58.3 Version was hash
+# https://github.com/conda-forge/glib-feedstock/blob/c1fb9a888690e674395fe7b8ce94f3fb67bd22bc/recipe/meta.yaml
+{% set version = "2.58.3" %}
 {% set major_minor = ".".join(version.split(".")[:2]) %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -9,7 +11,7 @@ package:
 
 source:
   url: http://ftp.gnome.org/pub/GNOME/sources/glib/{{ major_minor }}/glib-{{ version }}.tar.xz
-  sha256: 79f31365a99cb1cc9db028625635d1438890702acde9e2802eae0acebcf7b5b1
+  sha256: 8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481
   patches:
     # Related to this patch https://bugzilla.gnome.org/show_bug.cgi?id=673135
     # However, it was rejected by upstream. Homebrew decided to keep their own
@@ -31,7 +33,7 @@ source:
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
 build:
-  number: 1
+  number: 1005
   ignore_run_exports_from:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ source:
     - hardcoded-paths.patch
 
     # skip some problematic tests
-    - skip-gio-tests-meson.build.patch
-    - skip-gio-tests-resources.c.patch
-    - skip-glib-tests-fileutils.c.patch
+    # - skip-gio-tests-meson.build.patch
+    # - skip-gio-tests-resources.c.patch
+    # - skip-glib-tests-fileutils.c.patch
 
-    #- 0001-Attempt-to-mask-out-qemu-failing-tests.patch               # [ppc64le or aarch64]
+    - 0001-Attempt-to-mask-out-qemu-failing-tests.patch               # [ppc64le or aarch64]
     # Windows:
     - 0001-Manually-link-with-libiconv-whenever-we-use-libintl.patch  # [win]
     - 0002-Increase-some-test-timeouts.patch                          # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,6 @@ requirements:
     - zlib
     - pcre
     - libiconv
-  run_constrained:
-    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
 
 outputs:
   - name: libglib
@@ -96,7 +94,6 @@ outputs:
       run_constrained:
         # Avoid colliding with older glib builds that didn't have a libglib output
         - glib {{ version }} *_{{ PKG_BUILDNUM }}
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
     test:
       commands:
         - test -f ${PREFIX}/lib/libglib-2.0{{ SHLIB_EXT }}  # [not win]

--- a/recipe/skip-some-tests.patch
+++ b/recipe/skip-some-tests.patch
@@ -1,0 +1,64 @@
+rrrrrcommit 10dba9cd6d5e5b10bbccad44c5a426f11830bf02
+Author: Peter Williams <peter@newton.cx>
+Date:   Mon Sep 3 22:23:25 2018 -0400
+
+    All-plat patch: no_fileutils_test
+
+diff --git a/glib/tests/fileutils.c b/glib/tests/fileutils.c
+index c2a553b..18c96ff 100644
+--- a/glib/tests/fileutils.c
++++ b/glib/tests/fileutils.c
+@@ -1168,7 +1168,7 @@ main (int   argc,
+   g_test_add_func ("/fileutils/mkdtemp", test_mkdtemp);
+   g_test_add_func ("/fileutils/set-contents", test_set_contents);
+   g_test_add_func ("/fileutils/read-link", test_read_link);
+-  g_test_add_func ("/fileutils/stdio-wrappers", test_stdio_wrappers);
++  // g_test_add_func ("/fileutils/stdio-wrappers", test_stdio_wrappers);
+   g_test_add_func ("/fileutils/fopen-modes", test_fopen_modes);
+ 
+   return g_test_run ();
+diff --git a/gio/tests/meson.build b/gio/tests/meson.build
+index dca33bd..55dedc3 100644
+--- a/gio/tests/meson.build
++++ b/gio/tests/meson.build
+@@ -41,7 +41,6 @@ gio_tests = [{
+   'credentials' : {},
+   'data-input-stream' : {},
+   'data-output-stream' : {},
+-  'defaultvalue' : {'extra_sources' : [giotypefuncs_inc]},
+   'fileattributematcher' : {},
+   'filter-streams' : {},
+   'giomodule' : {},
+@@ -125,10 +124,6 @@ endif
+ if host_machine.system() != 'windows'
+   gio_tests += [{
+     'file' : {},
+-    'gdbus-peer' : {
+-      'dependencies' : [libgdbus_example_objectmanager_dep],
+-      'install_rpath' : installed_tests_execdir
+-    },
+     'gdbus-peer-object-manager' : {},
+     'live-g-file' : {},
+     'socket-address' : {},
+@@ -141,21 +136,6 @@ if host_machine.system() != 'windows'
+     'trash' : {},
+   }]
+ 
+-  # Uninstalled because of the check-for-executable logic in DesktopAppInfo
+-  # unable to find the installed executable
+-  if not glib_have_cocoa
+-    gio_tests += [{
+-      'appinfo' : {
+-        'install' : false,
+-        'is_parallel' : false,
+-      },
+-      'desktop-app-info' : {
+-        'install' : false,
+-        'is_parallel' : false,
+-      },
+-    }]
+-  endif
+-
+   test_extra_programs += [{
+     'basic-application' : {},
+     'dbus-launch' : {},


### PR DESCRIPTION
We are pinning to 2.58 and I think i'm getting a strange error due to it on 
https://github.com/conda-forge/libvips-feedstock/pull/20

I think we should make this a sacred branch, or unpin OSX.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
