### PR TITLE
Move a few more binaries to glib-tools

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG: linux_64_
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG: linux_ppc64le_
   timeoutInMinutes: 360
 
   steps:
@@ -36,9 +38,43 @@ jobs:
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+          export IS_PR_BUILD="True"
+        else
+          export IS_PR_BUILD="False"
+        fi
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
+        fi
+        ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,9 +11,11 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
 
   steps:
@@ -23,9 +25,43 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+      # Archive everything in CONDA_BLD_DIR except environments
+      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Archive the CONDA_BLD_DIR environments only when the job fails
+        export ENV_ARTIFACT_PREFIX=conda_envs
+      fi
+      ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -92,6 +93,33 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
+        set CI=azure
+        set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        set FEEDSTOCK_NAME=$(build.Repository.Name)
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
+        set CONDA_BLD_DIR=$(CONDA_BLD_PATH)
+        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        if "%AGENT_JOBSTATUS%" == "Failed" (
+            set ENV_ARTIFACT_PREFIX=conda_envs
+        )
+        call ".scripts\create_conda_build_artifacts.bat"
+      displayName: Prepare conda build artifacts
+      condition: succeededOrFailed()
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build artifacts
+      condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(BLD_ARTIFACT_PATH)
+        artifactName: $(BLD_ARTIFACT_NAME)
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build environment artifacts
+      condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(ENV_ARTIFACT_PATH)
+        artifactName: $(ENV_ARTIFACT_NAME)
+    - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
         validate_recipe_outputs "%FEEDSTOCK_NAME%"
@@ -107,4 +135,4 @@ jobs:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
-      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
     - export CI=drone
     - export GIT_BRANCH="$DRONE_BRANCH"
     - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - export IS_PR_BUILD=$(if [[ "$${DRONE_PULL_REQUEST:-}" == "" ]]; then echo "False"; else echo "True"; fi)
     - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
     - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
     - echo "Done building"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -66,7 +66,7 @@ else
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 
-    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
 

--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -1,0 +1,80 @@
+setlocal enableextensions enabledelayedexpansion
+
+rem INPUTS (environment variables that need to be set before calling this script):
+rem
+rem CI (azure/github_actions/UNSET)
+rem CI_RUN_ID (unique identifier for the CI job run)
+rem FEEDSTOCK_NAME
+rem CONFIG (build matrix configuration string)
+rem SHORT_CONFIG (uniquely-shortened configuration string)
+rem CONDA_BLD_DIR (path to the conda-bld directory)
+rem ARTIFACT_STAGING_DIR (use working directory if unset)
+rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+rem OUTPUTS
+rem
+rem BLD_ARTIFACT_NAME
+rem BLD_ARTIFACT_PATH
+rem ENV_ARTIFACT_NAME
+rem ENV_ARTIFACT_PATH
+
+rem Check that the conda-build directory exists
+if not exist %CONDA_BLD_DIR% (
+    echo conda-build directory does not exist
+    exit 1
+)
+
+if not defined ARTIFACT_STAGING_DIR (
+    rem Set staging dir to the working dir
+    set ARTIFACT_STAGING_DIR=%cd%
+)
+
+rem Set a unique ID for the artifact(s), specialized for this particular job run
+set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
+    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
+)
+
+rem Set a descriptive ID for the archive(s), specialized for this particular job run
+set ARCHIVE_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+
+rem Make the build artifact zip
+if defined BLD_ARTIFACT_PREFIX (
+    set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
+    echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
+
+    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    if errorlevel 1 exit 1
+    echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
+        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+    )
+)
+
+rem Make the environments artifact zip
+if defined ENV_ARTIFACT_PREFIX (
+    set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+    echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+
+    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
+    if errorlevel 1 exit 1
+    echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
+        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+    )
+)

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
+        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
+        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+    fi
+fi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -75,12 +75,14 @@ fi
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
+export IS_PR_BUILD="${IS_PR_BUILD:-False}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e IS_PR_BUILD \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,7 +9,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
@@ -66,7 +66,7 @@ validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 ( startgroup "Uploading packages" ) 2> /dev/null
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -13,6 +13,7 @@ import platform
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    os.environ["IS_PR_BUILD"] = "True"
     if ns.debug:
         os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
         if ns.output_id:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,4 @@
+azure: {store_build_artifacts: true}
 build_platform:
   osx_arm64: osx_64
   linux_ppc64le: linux_64

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -39,6 +39,8 @@ if NOT [%PKG_NAME%] == [glib] (
   rmdir /s /q %LIBRARY_PREFIX%\include\glib-2.0
   if errorlevel 1 exit 1
 
+  rmdir /s /q %LIBRARY_PREFIX%\lib\glib-2.0\include
+  if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\lib\pkgconfig\gio-*
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\lib\pkgconfig\glib-*

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -34,9 +34,9 @@ if NOT [%PKG_NAME%] == [glib] (
   del %LIBRARY_PREFIX%\bin\gtester*
   if errorlevel 1 exit 1
 
-  del /q %LIBRARY_PREFIX%\include\gio-win32-2.0
+  rmdir /s /q %LIBRARY_PREFIX%\include\gio-win32-2.0
   if errorlevel 1 exit 1
-  del /q %LIBRARY_PREFIX%\include\glib-2.0
+  rmdir /s /q %LIBRARY_PREFIX%\include\glib-2.0
   if errorlevel 1 exit 1
 
   del %LIBRARY_PREFIX%\lib\pkgconfig\gio-*
@@ -54,9 +54,9 @@ if NOT [%PKG_NAME%] == [glib] (
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\share\aclocal\gsettings.m4
   if errorlevel 1 exit 1
-  del /q %LIBRARY_PREFIX%\share\gettext\its
+  rmdir /s /q %LIBRARY_PREFIX%\share\gettext\its
   if errorlevel 1 exit 1
-  del /q %LIBRARY_PREFIX%\share\glib-2.0
+  rmdir /s /q %LIBRARY_PREFIX%\share\glib-2.0
   if errorlevel 1 exit 1
 )
 

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -16,16 +16,6 @@ if NOT [%PKG_NAME%] == [glib] (
       if errorlevel 1 exit 1
       del %LIBRARY_PREFIX%\bin\gsettings.exe
       if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\share\bash-completion\completions\gapplication
-      if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\share\bash-completion\completions\gdbus
-      if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\share\bash-completion\completions\gio
-      if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\share\bash-completion\completions\gresource
-      if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\share\bash-completion\completions\gsettings
-      if errorlevel 1 exit 1
   )
   del %LIBRARY_PREFIX%\bin\gdbus-codegen
   if errorlevel 1 exit 1
@@ -44,9 +34,9 @@ if NOT [%PKG_NAME%] == [glib] (
   del %LIBRARY_PREFIX%\bin\gtester*
   if errorlevel 1 exit 1
 
-  del %LIBRARY_PREFIX%\include\gio-win32-2.0
+  del /q %LIBRARY_PREFIX%\include\gio-win32-2.0
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\include\glib-2.0
+  del /q %LIBRARY_PREFIX%\include\glib-2.0
   if errorlevel 1 exit 1
 
   del %LIBRARY_PREFIX%\lib\pkgconfig\gio-*
@@ -64,10 +54,20 @@ if NOT [%PKG_NAME%] == [glib] (
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\share\aclocal\gsettings.m4
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\share\gettext\its
+  del /q %LIBRARY_PREFIX%\share\gettext\its
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\share\glib-2.0
+  del /q %LIBRARY_PREFIX%\share\glib-2.0
   if errorlevel 1 exit 1
 )
+
+rem We don't have bash as a dependency so these shouldn't exist, but
+rem sometimes a system bash will be picked up and they will get installed.
+rem Just delete them, but don't check for errors in case they do not exist.
+rem If we do want them in the future, they should go in glib-tools.
+del %LIBRARY_PREFIX%\share\bash-completion\completions\gapplication
+del %LIBRARY_PREFIX%\share\bash-completion\completions\gdbus
+del %LIBRARY_PREFIX%\share\bash-completion\completions\gio
+del %LIBRARY_PREFIX%\share\bash-completion\completions\gresource
+del %LIBRARY_PREFIX%\share\bash-completion\completions\gsettings
 
 del %LIBRARY_PREFIX%\bin\*.pdb

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -4,59 +4,69 @@ if errorlevel 1 exit 1
 
 if NOT [%PKG_NAME%] == [glib] (
   if [%PKG_NAME%] == [libglib] (
+      del %LIBRARY_PREFIX%\bin\gdbus.exe
+      if errorlevel 1 exit 1
       del %LIBRARY_PREFIX%\bin\gio-querymodules.exe
       if errorlevel 1 exit 1
       del %LIBRARY_PREFIX%\bin\gio.exe
       if errorlevel 1 exit 1
-      del %LIBRARY_PREFIX%\bin\glib-compile-resources.exe
-      if errorlevel 1 exit 1
       del %LIBRARY_PREFIX%\bin\glib-compile-schemas.exe
       if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\bin\gresource.exe
+      if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\bin\gsettings.exe
+      if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\share\bash-completion\completions\gapplication
+      if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\share\bash-completion\completions\gdbus
+      if errorlevel 1 exit 1
       del %LIBRARY_PREFIX%\share\bash-completion\completions\gio
+      if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\share\bash-completion\completions\gresource
+      if errorlevel 1 exit 1
+      del %LIBRARY_PREFIX%\share\bash-completion\completions\gsettings
       if errorlevel 1 exit 1
   )
   del %LIBRARY_PREFIX%\bin\gdbus-codegen
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\bin\gdbus.exe
+  del %LIBRARY_PREFIX%\bin\glib-compile-resources.exe
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\bin\glib-genmarshal
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\bin\glib-gettextsize
+  del %LIBRARY_PREFIX%\bin\glib-gettextize
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\bin\glib-mkenums
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\bin\gobject-query
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\bin\gresource.exe
-  if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\bin\gsettings.exe
+  del %LIBRARY_PREFIX%\bin\gobject-query.exe
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\bin\gspawn*
   if errorlevel 1 exit 1
   del %LIBRARY_PREFIX%\bin\gtester*
   if errorlevel 1 exit 1
 
-  del %LIBRARY_PREFIX%\include\glib*
+  del %LIBRARY_PREFIX%\include\gio-win32-2.0
+  if errorlevel 1 exit 1
+  del %LIBRARY_PREFIX%\include\glib-2.0
   if errorlevel 1 exit 1
 
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gio*
+  del %LIBRARY_PREFIX%\lib\pkgconfig\gio-*
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\glib*
+  del %LIBRARY_PREFIX%\lib\pkgconfig\glib-*
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gmodule*
+  del %LIBRARY_PREFIX%\lib\pkgconfig\gmodule-*
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gobject*
+  del %LIBRARY_PREFIX%\lib\pkgconfig\gobject-*
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\lib\pkgconfig\gthread*
+  del %LIBRARY_PREFIX%\lib\pkgconfig\gthread-*
   if errorlevel 1 exit 1
 
-  del %LIBRARY_PREFIX%\share\bash-completion\completions\gapplication
+  del %LIBRARY_PREFIX%\share\aclocal\glib-*
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\share\bash-completion\completions\gdbus
+  del %LIBRARY_PREFIX%\share\aclocal\gsettings.m4
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\share\bash-completion\completions\gresource
+  del %LIBRARY_PREFIX%\share\gettext\its
   if errorlevel 1 exit 1
-  del %LIBRARY_PREFIX%\share\bash-completion\completions\gsettings
+  del %LIBRARY_PREFIX%\share\glib-2.0
   if errorlevel 1 exit 1
 )
 

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -21,21 +21,26 @@ if [[ "$PKG_NAME" == glib ]]; then
 else
     if [[ "$PKG_NAME" == glib-tools ]]; then
         mkdir .keep
-        # We ship glib-compile-* and gio-* binaries as part of the libglib packages
-        # as they are native binaries and also come along inside of libglib
-        # in other distributions.
-        mv $PREFIX/bin/glib-compile* .keep
+        # We ship these binaries as part of the glib-tools package because
+        # they can be depended on separately by other packages, e.g. gtk
+        # (equivalent to Debian's libglib2.0-bin)
+        mv $PREFIX/bin/gdbus .keep
+        mv $PREFIX/bin/glib-compile-schemas .keep
     else
+        rm -f $PREFIX/bin/gapplication
         rm $PREFIX/bin/gio*
-        rm -r $PREFIX/share/bash-completion/completions/gio
+        rm $PREFIX/bin/gresource
+        rm $PREFIX/bin/gsettings
+        rm $PREFIX/share/bash-completion/completions/{gapplication,gdbus,gio,gresource,gsettings}
     fi
-    rm $PREFIX/bin/gdbus* $PREFIX/bin/glib* $PREFIX/bin/gobject* $PREFIX/bin/gresource $PREFIX/bin/gsettings $PREFIX/bin/gtester*
+    rm $PREFIX/bin/{gdbus*,glib-*,gobject*,gtester*}
     if [[ "$PKG_NAME" == glib-tools ]]; then
-        mv .keep/glib-compile* $PREFIX/bin
+        mv .keep/* $PREFIX/bin
     fi
     rm -r $PREFIX/include/gio-* $PREFIX/include/glib-*
-    rm -r $PREFIX/share/aclocal/{glib*,gsettings*}
-    rm -r $PREFIX/share/bash-completion/completions/{gapplication,gdbus,gresource,gsettings}
-    rm -r $PREFIX/share/glib-*
+    rm -r $PREFIX/lib/glib-*
     rm -r $PREFIX/lib/lib{gmodule,glib,gobject,gthread,gio}-2.0${SHLIB_EXT}
+    rm -r $PREFIX/share/aclocal/{glib-*,gsettings*}
+    rm -r $PREFIX/share/gettext/its
+    rm -r $PREFIX/share/glib-*
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports_from:
     - python *
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,10 +114,13 @@ outputs:
         - {{ pin_subpackage("libglib", exact=True) }}
     test:
       commands:
-        - glib-compile-schemas --help
-        - glib-compile-resources --help
+        # Check that binaries can run -- instigated by Meson Linux rpath issue
+        - gapplication help  # [linux]
+        - gdbus help
         - gio version
         - gio-querymodules .
+        - glib-compile-schemas --help
+        - gresource help
   - name: glib
     script: install.sh  # [unix]
     script: install.bat  # [not unix]
@@ -148,11 +151,8 @@ outputs:
     test:
       commands:
         - test -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
-        # Check that binaries can run -- instigated by Meson Linux rpath issue
-        - gapplication help  # [linux]
-        - gdbus help
+        - glib-compile-resources --help
         - gobject-query --help
-        - gresource help
         - gtester --help  # [not win]
 
 about:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes https://github.com/conda-forge/gtk3-feedstock/issues/40.

<!--
Please add any other relevant info below:
-->

These tools, notably gdbus, are needed by e.g. gtk3 at runtime, but other packages compiling against glib don't necessarily need them in libglib.

This also shifts some extra things that are only needed at build time from libglib to glib (e.g. gettext, a stray gapplication binary). Finally, glib-compile-resource moves from glib-tools to glib since it is only needed at build time.

This organization roughly matches Debian:
libglib == libglib2.0 and libglib2.0-data
glib-tools == libglib2.0-bin
glib == libglib2.0-dev and libglib2.0-dev-bin