### PR TITLE
Move activation scripts from glib output to libglib

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -12,15 +12,7 @@ find $PREFIX -name '*.la' -delete
 # (255 chars) which causes installation issues so remove it.
 rm -rf $PREFIX/share/gdb
 
-if [[ "$PKG_NAME" == glib ]]; then
-    # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
-    # This will allow them to be run on environment activation.
-    for CHANGE in "activate" "deactivate"
-    do
-        mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-        cp "${RECIPE_DIR}/scripts/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
-     done
-else
+if [[ "$PKG_NAME" != glib ]]; then
     if [[ "$PKG_NAME" == glib-tools ]]; then
         mkdir .keep
         # We ship these binaries as part of the glib-tools package because
@@ -34,6 +26,14 @@ else
         rm $PREFIX/bin/gresource
         rm $PREFIX/bin/gsettings
         rm $PREFIX/share/bash-completion/completions/{gapplication,gdbus,gio,gresource,gsettings}
+
+        # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+        # This will allow them to be run on environment activation.
+        for CHANGE in "activate" "deactivate"
+        do
+            mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+            cp "${RECIPE_DIR}/scripts/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+        done
     fi
     rm $PREFIX/bin/{gdbus*,glib-*,gobject*,gtester*}
     if [[ "$PKG_NAME" == glib-tools ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,6 +92,8 @@ outputs:
         - test ! -f ${PREFIX}/lib/libgobject-2.0.la  # [not win]
         - test ! -f ${PREFIX}/lib/libglib-2.0${SHLIB_EXT}  # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/glib-2.0.pc  # [unix]
+        - test -f ${PREFIX}/etc/conda/activate.d/libglib_activate.sh  # [not win]
+        - test -f ${PREFIX}/etc/conda/deactivate.d/libglib_deactivate.sh  # [not win]
   - name: glib-tools
     script: install.sh  # [unix]
     script: install.bat  # [not unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ source:
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports_from:
     - python *
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I've recently seen reports from users of `gtk3` with error messages like
```
GLib-GIO-ERROR **: 09:57:12.172: Settings schema 'org.gtk.Settings.FileChooser' does not contain a key named 'type-format'
```
and I tracked it down to `GSETTINGS_SCHEMA_DIR` not being set (i.e. same problem originally solved by #49). This is starting to crop up now that packages building against `glib` only have a runtime dependency on `libglib`, and `libglib` does not contain the activation script that sets `GSETTINGS_SCHEMA_DIR`. This PR moves the activation scripts to the `libglib` output so that they are always present when the library is used at runtime.