### PR TITLE
Add dep on `packaging` for `gdbus-codegen`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,7 +72,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,6 @@
 set -exuo pipefail
 
 meson_config_args=(
-     --buildtype=release
      --backend=ninja
      -Dlibdir=lib
      -Dlibmount=disabled

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     - 0002-Increase-some-test-timeouts.patch                          # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports_from:
     - python *
 
@@ -187,6 +187,12 @@ outputs:
         - zlib
       run:
         - python *
+        # The `packaging` Python module is needed by gdbus-codegen. In certain
+        # build scenarios, that script is unavoidably executed by a Python
+        # interpreter different from the one installed into the "run"
+        # environment, so you may need to explicitly add a dep on `packaging`
+        # elsewhere. See https://github.com/conda-forge/glib-feedstock/pull/182
+        - packaging
         - {{ pin_subpackage("libglib", exact=True) }}
         - {{ pin_subpackage("glib-tools", exact=True) }}
         # glib headers depend on libintl headers
@@ -203,6 +209,7 @@ outputs:
         - glib-compile-resources --help
         - gobject-query --help
         - gtester --help  # [not win]
+        - gdbus-codegen --help  # [not win]
         - ${CC} ${LDFLAGS} ${CFLAGS} test.c $(pkg-config --cflags --libs glib-2.0) -o test-glib && ./test-glib  # [unix]
         - test-win.bat  # [win]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

As seen in https://github.com/conda-forge/gtk4-feedstock/pull/55 , the `gdbus-codegen` tool provided in the `glib` package requires the `packaging` Python package. So, require it.