### PR TITLE
Enable even_odd_versions in bot configuration

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,6 @@ github:
   branch_name: main
   tooling_branch_name: main
 test: native_and_emulated
+bot:
+  version_updates:
+    even_odd_versions: true


### PR DESCRIPTION
This PR enables the `even_odd_versions` setting in the bot section of conda-forge.yml to prevent automated updates to unstable versions.