### PR TITLE
fix: strip Requires.private from .pc files to fix pkg-config failures

### DIFF
--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -73,6 +73,11 @@ fi
 rm -r $PREFIX/lib/glib-*
 
 if [[ "$PKG_NAME" == "libglib" ]]; then
+    # Remove Requires.private — unnecessary on conda-forge (no static linking,
+    # CFEP-18) and causes build failures when transitive .pc files are absent
+    # See: https://github.com/conda-forge/glib-feedstock/issues/205
+    sed -i.bak '/^Requires\.private:/d' ${PREFIX}/lib/pkgconfig/*.pc
+    rm ${PREFIX}/lib/pkgconfig/*.pc.bak
     rm -r $PREFIX/lib/lib{gmodule,glib,gobject,gthread,gio}-2.0${SHLIB_EXT}
 elif [[ "$PKG_NAME" != "glib-tools" ]]; then
     rm -r $PREFIX/include/gio-* $PREFIX/include/glib-*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - patches/0005-Increase-some-test-timeouts.patch                           # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports_from:
     - python *
 


### PR DESCRIPTION
Removes Requires.private lines from all .pc files in the libglib package. These reference packages (e.g. zlib) whose .pc files aren't co-installed, breaking pkg-config for downstream consumers. Static linking is prohibited by CFEP-18, so the field is unnecessary.

Fixes: https://github.com/conda-forge/glib-feedstock/issues/205

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
