### PR TITLE
Remove fake gobject-introspection-1.0.pc file from the libglib package

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -74,6 +74,11 @@ sed -e "s|g_ir_scanner=.*|g_ir_scanner=${BUILD_PREFIX}/bin/g-ir-scanner|" \
 # path, to pull in deps of the gobject-introspection (namely, glib)
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${GIR_PREFIX}/lib/pkgconfig"
 
+# We also need to make a backup of our fake pkg-config file. The install scripts
+# need it to freshen the build, but each invocation also needs to remove it from
+# $PREFIX so that the file doesn't make it into our final packages.
+cp ${PREFIX}/lib/pkgconfig/gobject-introspection-1.0.pc conda-private-gobject-introspection-1.0.pc
+
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == 1 ]]; then
   unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
   (

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -18,10 +18,16 @@ exec ${GIR_PREFIX}/bin/python3 ${GIR_PREFIX}/bin/g-ir-scanner "\$@"
 EOF
 chmod +x $BUILD_PREFIX/bin/g-ir-scanner
 
+# this file may need to be recreated as well:
+cp conda-private-gobject-introspection-1.0.pc ${PREFIX}/lib/pkgconfig/gobject-introspection-1.0.pc
+
 ninja -C builddir install || (cat builddir/meson-logs/meson-log.txt; false)
 
 # remove libtool files
 find $PREFIX -name '*.la' -delete
+
+# make sure this doesn't make it into any of our packages
+rm -f ${PREFIX}/lib/pkgconfig/gobject-introspection-1.0.pc
 
 # gdb folder has a nested folder structure similar to our host prefix
 # (255 chars) which causes installation issues so remove it.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -149,6 +149,7 @@ outputs:
             - if not exist %LIBRARY_PREFIX%\lib\girepository-1.0\GLib-2.0.typelib exit 1
             - if not exist %LIBRARY_PREFIX%\lib\girepository-2.0.lib exit 1
             - if not exist %LIBRARY_PREFIX%\lib\pkgconfig\girepository-2.0.pc exit 1
+            - if exist %LIBRARY_PREFIX%\lib\pkgconfig\gobject-introspection-1.0.pc exit 1
             - if not exist %LIBRARY_PREFIX%\include\glib-2.0\girepository\girepository.h exit 1
           else:
             - test ! -f ${PREFIX}/lib/libgobject-2.0.la
@@ -161,6 +162,7 @@ outputs:
             - test -f ${PREFIX}/share/gir-1.0/GLib-2.0.gir
             - test -f ${PREFIX}/lib/girepository-1.0/GLib-2.0.typelib
             - test -f ${PREFIX}/lib/pkgconfig/girepository-2.0.pc
+            - test ! -f ${PREFIX}/lib/pkgconfig/gobject-introspection-1.0.pc
             - test -f ${PREFIX}/include/glib-2.0/girepository/girepository.h
 
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,7 +40,7 @@ source:
         - patches/0006-Skip-flaky-tests-on-linux64-CI.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - staging:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The past few Linux/Mac builds have accidentally been including a fake version of the gobject-introspection-1.0.pc pkg-config file in the `libglib` package. Make sure that doesn't happen.