### PR TITLE
Minor tidying / investigate build number weirdness

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -92,12 +92,7 @@ outputs:
       name: libglib
     inherit: glib-build
     build:
-      script:
-        - if: unix
-          then:
-            - install.sh
-          else:
-            - install.bat
+      script: install
     requirements:
       ignore_run_exports:
         from_package:
@@ -171,12 +166,7 @@ outputs:
       from: glib-build
       run_exports: false
     build:
-      script:
-        - if: unix
-          then:
-            - install.sh
-          else:
-            - install.bat
+      script: install
     requirements:
       ignore_run_exports:
         from_package:
@@ -233,12 +223,7 @@ outputs:
       from: glib-build
       run_exports: false
     build:
-      script:
-        - if: unix
-          then:
-            - install.sh
-          else:
-            - install.bat
+      script: install
     requirements:
       ignore_run_exports:
         from_package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,7 +40,7 @@ source:
         - patches/0006-Skip-flaky-tests-on-linux64-CI.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - staging:


### PR DESCRIPTION
@wolfv in #238, I fixed a packaging bug and bumped the build number to 1 in the usual way. But I just noticed that the builds (both in the PR and after merging to main) all ran with a build number of zero, all the way up until the "Validating outputs" and "Uploading packages" stages, where the rattler output shows the correct build number of 1.

I feel like this must be a rattler-build bug — would you agree? From my reading of the docs, the recipe should work as written.

This test PR applies the tidying that you mentioned and should demonstrate the same problem. I'm not bumping the build number here because only 2.88.0 ... _0 has been published.

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.